### PR TITLE
Fixed Uninitialized Variables

### DIFF
--- a/src/Drive.cpp
+++ b/src/Drive.cpp
@@ -267,8 +267,8 @@ void CDrive::VisionTick()
 	double dErrorRight;
 	double dGainLeft;
 	double dGainRight;
-	double dSpeedLeft;
-	double dSpeedRight;
+	double dSpeedLeft  = 0.00;
+	double dSpeedRight = 0.00;
 	// Calculate Center Point on X Axis.
 	dxCenter	 	= ((SmartDashboard::GetNumber("VisionObjectCenter", dCameraCenter)));
 	// Calculate Setpoints with Tolerance
@@ -285,7 +285,7 @@ void CDrive::VisionTick()
 	dDetectSize 	= SmartDashboard::GetNumber("VisionObjectSize", 0);
 
 	// The object is close, stop motors.
-	if (dDetectSize == 48)
+	if (dDetectSize <= 48)
 	{
 		dSpeedLeft  = 0.000;
 		dSpeedRight = 0.000;

--- a/src/Gripper.cpp
+++ b/src/Gripper.cpp
@@ -369,8 +369,8 @@ void CGripper::GripperStateMachine()
 			SmartDashboard::PutString("Gripper State", "Floor Eject - Delay Closing Claw");
 
 			// Get the delay to close claw from the dashboard.
-			dFloorEjectStopMotorDelay = SmartDashboard::GetNumber("Scale Eject Close Claw Delay", dDefaultScaleEjectCloseClawDelay);
-			if (m_pTimer->Get() > (m_dDelayStartTime + dScaleEjectCloseClawDelay))
+			dFloorEjectStopMotorDelay = SmartDashboard::GetNumber("Floor Eject Stop Motor Delay", dDefaultFloorEjectStopMotorDelay);
+			if (m_pTimer->Get() > (m_dDelayStartTime + dFloorEjectStopMotorDelay))
 			{
 				// Move to Gripper Idle state.
 				m_nGripperState = eGripperIdle;

--- a/src/RobotMain.cpp
+++ b/src/RobotMain.cpp
@@ -1251,7 +1251,7 @@ void CRobotMain::TeleopPeriodic()
 	/********************************************************************
 		Drive Controller - Call vision tick if button is held down.
 	********************************************************************/
-	static bool bGripperSet = false;
+///	static bool bGripperSet = false;
 
 	// Check to see if Left Trigger was pressed.
 	if (m_pDriveController->GetRawAxis(2) >= 0.5) // Note that this should be looped.
@@ -1278,7 +1278,7 @@ void CRobotMain::TeleopPeriodic()
 		// Reset to Joystick control to avoid "sluggish motor syndrome."
 		m_pDrive->Init();
 		// The gripper should no longer be set, set it to false.
-		bGripperSet = false;
+///		bGripperSet = false;
 		m_bDriveControllerLeftTriggerPressed = false;
 	}
 


### PR DESCRIPTION
A few variables were throwing warnings during compilation. Also fixed one of the variables in the Gripper class that was being represented incorrectly for a timing.