### PR TITLE
Added streaming functionality of processed images to driver station.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ optional arguments:
                             Path to video file or integer representing webcam
                             index (default 0).
     --thread THREAD, -t THREAD
-                            Threading mode: both (video read and video show in
+                            Threading mode: all (video read and video show in
                             their own threads), none (default--no multithreading)
     --gui GUI, -g GUI     Graphical User Interface: yes (show video windows for 
                             vision tuning), no (default, run supa fast)

--- a/vision/multi-threading/VideoGet.py
+++ b/vision/multi-threading/VideoGet.py
@@ -1,4 +1,5 @@
 from threading import Thread
+#from multiprocessing import Process
 import numpy
 import cv2
 

--- a/vision/multi-threading/VideoProcess.py
+++ b/vision/multi-threading/VideoProcess.py
@@ -1,4 +1,5 @@
 from threading import Thread
+#from multiprocessing import Process
 import numpy as np
 import cv2
 import cv2 as cv
@@ -16,6 +17,7 @@ class VideoProcess:
         self.gui = gui
         self.mode = "free"
         self.frame = frame
+        self.processedFrame = frame
         self.resolution = resolution
         self.speed = self.cps.countsPerSec()
         self.trackbarValues = trackbarValues
@@ -23,10 +25,10 @@ class VideoProcess:
         self.stopped = False
 
     def start(self):
-        Thread(target=self.trackObject, args=()).start()
+        Thread(target=self.detectObject, args=()).start()
         return self
 
-    def trackObject(self):
+    def detectObject(self):
         # Create variables.
         setPosition = True
         sameAsBefore = 0
@@ -166,7 +168,10 @@ class VideoProcess:
                 cv2.imshow("Closed", closed)
                 cv2.imshow("Edged", edged)
                 cv2.imshow("Tracking", frame)
-                
+
+            # Send the final frame for streaming.
+            self.processedFrame = frame
+
             # Increment counts per second.
             self.cps.increment()
             self.speed = self.cps.countsPerSec()

--- a/vision/multi-threading/VideoStream.py
+++ b/vision/multi-threading/VideoStream.py
@@ -1,0 +1,94 @@
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from SocketServer import ThreadingMixIn
+from threading import Thread
+import threading
+from PIL import Image
+import StringIO
+import numpy
+import time
+import cv2
+
+class socketHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.endswith(".mjpg"):
+            self.send_response(200)
+            self.send_header("Content-type", "multipart/x-mixed-replace; boundary=--jpgboundary")
+            self.end_headers()
+            while True:
+                try:
+                    img = streamFrame
+                    scalePercent = 270
+                    width = int(img.shape[1] * scalePercent / 100)
+                    height = int(img.shape[0] * scalePercent / 100)
+                    dim = (width, height)
+                    # Resize image
+                    resized = cv2.resize(img, dim, interpolation = cv2.INTER_AREA)
+                    imgRGB = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB)
+                    jpg = Image.fromarray(imgRGB)
+                    tmpFile = StringIO.StringIO()
+                    jpg.save(tmpFile, "JPEG")
+                    self.wfile.write("--jpgboundary")
+                    self.send_header("Content-type", "image/jpeg")
+                    self.send_header("Content-length", str(tmpFile.len))
+                    self.end_headers()
+                    jpg.save(self.wfile, "JPEG")
+                    time.sleep(0.05)
+                except stopped:
+                    break
+            return
+        if self.path.endswith(".html"):
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write("<html><head></head><body>")
+            self.wfile.write('<img src="http://192.168.43.106:8080/cam.mjpg"/>')
+            self.wfile.write("</body></html>")
+            return
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    '''
+    Handle requests in a separate thread.
+    ''' 
+
+class HTTPRefresher():
+    '''
+    Constantly searches for new requests.
+    '''
+    def start(self):
+        Thread(target=self.refresh, args=()).start()
+        return self
+    
+    def refresh(self):
+        # Start HTTP server and process requests.
+        server = ThreadedHTTPServer(("192.168.43.106", 8080), socketHandler)
+        print "MJPG Streaming Server Started..."
+        server.serve_forever()
+
+class VideoStream():
+    def __init__(self, stopped, processedFrame = None):
+        # Create local variables.
+        self.processedFrame = processedFrame
+        self.stopped = False
+
+    def start(self):
+        Thread(target=self.stream, args=()).start()
+        return self
+
+    def stream(self):
+        # Create global variables.
+        global streamFrame
+        global stopped
+        global img
+        stopped = False
+        
+        # Run refresher in different class so that VideoStream can pass processedFrame.
+        HTTPRefresher().start()
+        
+        # Pass processedFrame to socketHandler.
+        while not self.stopped:
+            streamFrame = self.processedFrame
+            stopped = self.stopped
+            time.sleep(0.1)
+
+    def stop(self):
+        self.stopped = True

--- a/vision/multi-threading/VisionMain.py
+++ b/vision/multi-threading/VisionMain.py
@@ -1,8 +1,10 @@
 import argparse
 import cv2
 import time
-from VideoProcess import VideoProcess
 from VideoGet import VideoGet
+from VideoStream import VideoStream
+from VideoProcess import VideoProcess
+from CountsPerSec import CountsPerSec
 from VisionNetworking import VisionNetworking
 
 def putIterationsPerSec(frame, iterations_per_sec):
@@ -29,7 +31,7 @@ def noThreading(source=0):
         cv2.imshow("Video", frame)
         cps.increment()
         
-def threadBoth(gui, server, source=0):
+def multiThreading(gui, server, source=0):
     '''
     Dedicated thread for grabbing video frames with VideoGet object.
     Dedicated thread for processing and optionally showing video frames
@@ -39,23 +41,28 @@ def threadBoth(gui, server, source=0):
 
     # Create Object Pointers
     video_getter = VideoGet(source).start()
-    video_processor = VideoProcess(gui, video_getter.frame, video_getter.resolution).start()
+    video_processor = VideoProcess(gui, video_getter.frame, video_getter.resolution, [[0,0], [0,0], [0,0]]).start()
+    video_streamer = VideoStream(video_getter.stopped, video_processor.processedFrame).start()
     vision_networking = VisionNetworking(gui, server, video_processor.pointArray, video_getter.resolution).start()
-
+    
     # Main multithreading loop.
     while True:
         if video_getter.stopped or video_processor.stopped:
             video_processor.stop()
             vision_networking.stop()
             video_getter.stop()
+            video_streamer.stop()
+            cv2.destroyAllWindows()
             break
 
         # Pass camera frame between classes.
         frame = video_getter.frame                        # Grab frame from camera.
         video_processor.frame = frame                     # Push camera frame to VideoProcess class for vision processing.
+        stream = video_processor.processedFrame           # Grab the processed frame.
+        video_streamer.processedFrame = stream            # Push processed frame to VideoStream class.
         resolution = video_getter.resolution              # Grab camera resolution.
-        vision_networking.resolution = resolution         # Push camera resolution to VideoNetworking class and VideoProcess class.
-        video_processor.resolution = resolution
+        vision_networking.resolution = resolution         # Push camera resolution to VideoNetworking class.
+        video_processor.resolution = resolution           # Push camera resolution to VideoProcess class.
 
         # Pass required info between classes.
         trackbarValues = vision_networking.trackbarValues # Pass trackbar values from VisionNetworking to VisionProcess.
@@ -76,7 +83,7 @@ def main():
         help="Path to video file or integer representing webcam index"
             + " (default 0).")
     ap.add_argument("--thread", "-t", default="none",
-        help="Threading mode: both (video read and video show in their own threads),"
+        help="Threading mode: all (video read, process, streaming and networking run in their own threads),"
             + " none (default--no multithreading)")
     ap.add_argument("--gui", "-g", default="no",
         help="Graphical User Interface: yes (show video windows for vision tuning),"
@@ -85,8 +92,8 @@ def main():
         help="Server IP for NetworkTables communication. (default: 10.32.84.2)")
     args = vars(ap.parse_args())
 
-    if args["thread"] == "both":
-        threadBoth(args["gui"], args["server"], args["source"])
+    if args["thread"] == "all":
+        multiThreading(args["gui"], args["server"], args["source"])
     else:
         noThreading(args["source"])
 

--- a/vision/multi-threading/VisionNetworking.py
+++ b/vision/multi-threading/VisionNetworking.py
@@ -1,3 +1,4 @@
+#from multiprocessing import Process
 from threading import Thread
 import logging
 import numpy
@@ -34,12 +35,12 @@ class VisionNetworking:
         self.freeModeEnabled = self.NWTB.getEntry("VisionFreeMode")
         
         # Open values from files and set trackbar position.
-        self.hmnReadFree = open('/home/pi/Desktop/Values/FreeMode/hmn.txt', 'r')
-        self.hmxReadFree = open('/home/pi/Desktop/Values/FreeMode/hmx.txt', 'r')
-        self.smnReadFree = open('/home/pi/Desktop/Values/FreeMode/smn.txt', 'r')
-        self.smxReadFree = open('/home/pi/Desktop/Values/FreeMode/smx.txt', 'r')
-        self.vmnReadFree = open('/home/pi/Desktop/Values/FreeMode/vmn.txt', 'r')
-        self.vmxReadFree = open('/home/pi/Desktop/Values/FreeMode/vmx.txt', 'r')
+        self.hmnReadFree = open("/home/pi/Desktop/Values/FreeMode/hmn.txt", "r")
+        self.hmxReadFree = open("/home/pi/Desktop/Values/FreeMode/hmx.txt", "r")
+        self.smnReadFree = open("/home/pi/Desktop/Values/FreeMode/smn.txt", "r")
+        self.smxReadFree = open("/home/pi/Desktop/Values/FreeMode/smx.txt", "r")
+        self.vmnReadFree = open("/home/pi/Desktop/Values/FreeMode/vmn.txt", "r")
+        self.vmxReadFree = open("/home/pi/Desktop/Values/FreeMode/vmx.txt", "r")
         (self.trackbarValues[0][0]) = self.hmnReadFree.read()
         (self.trackbarValues[0][1]) = self.hmxReadFree.read()
         (self.trackbarValues[1][0]) = self.smnReadFree.read()
@@ -100,55 +101,55 @@ class VisionNetworking:
 
             # Check if the files or mode have changed and set trackbar values.
             if self.mode == "free":
-                hmnReadFree = open('/home/pi/Desktop/Values/FreeMode/hmn.txt', 'r')
+                hmnReadFree = open("/home/pi/Desktop/Values/FreeMode/hmn.txt", "r")
                 if (self.trackbarValues[0][0]) != hmnReadFree.read():
                     (self.trackbarValues[0][0]) = hmnReadFree.read()
-                hmxReadFree = open('/home/pi/Desktop/Values/FreeMode/hmx.txt', 'r')
+                hmxReadFree = open("/home/pi/Desktop/Values/FreeMode/hmx.txt", "r")
                 if (self.trackbarValues[0][1]) != hmxReadFree.read():
                     (self.trackbarValues[0][1]) = hmxReadFree.read()
-                smnReadFree = open('/home/pi/Desktop/Values/FreeMode/smn.txt', 'r')
+                smnReadFree = open("/home/pi/Desktop/Values/FreeMode/smn.txt", "r")
                 if (self.trackbarValues[1][0]) != smnReadFree.read():
                     (self.trackbarValues[1][0]) = smnReadFree.read()
-                smxReadFree = open('/home/pi/Desktop/Values/FreeMode/smx.txt', 'r')
+                smxReadFree = open("/home/pi/Desktop/Values/FreeMode/smx.txt", "r")
                 if (self.trackbarValues[1][1]) != smxReadFree.read():
                     (self.trackbarValues[1][1]) = smxReadFree.read()
-                vmnReadFree = open('/home/pi/Desktop/Values/FreeMode/vmn.txt', 'r')
+                vmnReadFree = open("/home/pi/Desktop/Values/FreeMode/vmn.txt", "r")
                 if (self.trackbarValues[2][0]) != vmnReadFree.read():
                     (self.trackbarValues[2][0]) = vmnReadFree.read()
-                vmxReadFree = open('/home/pi/Desktop/Values/FreeMode/vmx.txt', 'r')
+                vmxReadFree = open("/home/pi/Desktop/Values/FreeMode/vmx.txt", "r")
                 if (self.trackbarValues[2][1]) != vmxReadFree.read():
                     (self.trackbarValues[2][1]) = vmxReadFree.read()
 
             if self.mode == "tape":
-                hmnReadTape = open('/home/pi/Desktop/Values/TapeMode/hmn.txt', 'r')
+                hmnReadTape = open("/home/pi/Desktop/Values/TapeMode/hmn.txt", "r")
                 if (self.trackbarValues[0][0]) != hmnReadTape.read():
                     (self.trackbarValues[0][0]) = hmnReadTape.read()
-                hmxReadTape = open('/home/pi/Desktop/Values/TapeMode/hmx.txt', 'r')
+                hmxReadTape = open("/home/pi/Desktop/Values/TapeMode/hmx.txt", "r")
                 if (self.trackbarValues[0][1]) != hmxReadTape.read():
                     (self.trackbarValues[0][1]) = hmxReadTape.read()
-                smnReadTape = open('/home/pi/Desktop/Values/TapeMode/smn.txt', 'r')
+                smnReadTape = open("/home/pi/Desktop/Values/TapeMode/smn.txt", "r")
                 if (self.trackbarValues[1][0]) != smnReadTape.read():
                     (self.trackbarValues[1][0]) = smnReadTape.read()
-                smxReadTape = open('/home/pi/Desktop/Values/TapeMode/smx.txt', 'r')
+                smxReadTape = open("/home/pi/Desktop/Values/TapeMode/smx.txt", "r")
                 if (self.trackbarValues[1][1]) != smxReadTape.read():
                     (self.trackbarValues[1][1]) = smxReadTape.read()
-                vmnReadTape = open('/home/pi/Desktop/Values/TapeMode/vmn.txt', 'r')
+                vmnReadTape = open("/home/pi/Desktop/Values/TapeMode/vmn.txt", "r")
                 if (self.trackbarValues[2][0]) != vmnReadTape.read():
                     (self.trackbarValues[2][0]) = vmnReadTape.read()
-                vmxReadTape = open('/home/pi/Desktop/Values/TapeMode/vmx.txt', 'r')
+                vmxReadTape = open("/home/pi/Desktop/Values/TapeMode/vmx.txt", "r")
                 if (self.trackbarValues[2][1]) != vmxReadTape.read():
                     (self.trackbarValues[2][1]) = vmxReadTape.read()
 
             # Send telemtry data to webserver.
             seconds = int(time.time())
             if seconds % 2 == 0 and seconds != oldTime:
-                telemetryMode = open('/home/pi/Desktop/Values/Telemetry/mode.txt', 'w')
+                telemetryMode = open("/home/pi/Desktop/Values/Telemetry/mode.txt", "w")
                 telemetryMode.write(self.mode)
-                telemetrySpeed = open('/home/pi/Desktop/Values/Telemetry/speed.txt', 'w')
+                telemetrySpeed = open("/home/pi/Desktop/Values/Telemetry/speed.txt", "w")
                 telemetrySpeed.write(str(self.speed))
-                telemetryPointArray = open('/home/pi/Desktop/Values/Telemetry/pointarray.txt', 'w')
+                telemetryPointArray = open("/home/pi/Desktop/Values/Telemetry/pointarray.txt", "w")
                 telemetryPointArray.write(str(self.pointArray))
-                telemetryTrackbars = open('/home/pi/Desktop/Values/Telemetry/trackbarvalues.txt', 'w')
+                telemetryTrackbars = open("/home/pi/Desktop/Values/Telemetry/trackbarvalues.txt", "w")
                 telemetryTrackbars.write(str(self.trackbarValues))
                 oldTime = seconds
 
@@ -167,4 +168,3 @@ class VisionNetworking:
 
     def stop(self):
         self.stopped = True
-##        BackgroundScheduler().shutdown()


### PR DESCRIPTION
Now able to stream the processed video feed back to the driver station with vision tracking overlay using a MJPG server.

Features/Details:
-Accessible through any compatible web browser by visiting the URL. (eg. http://vision:8080/cam.mjpg)
-Video feed is currently capped at 10 FPS but can be increased at the cost of processing time.
-Runs at relatively low latency and has a delay similar to the CameraServer feed on the RoboRio.
-Processing speed has dropped about 4 FPS compared to when streaming is turned off. (runs at around 26 FPS instead of the previous 30 FPS) 

Known Issues:
-When the program is safely shutdown it stops all processes except for the ThreadedHTTPServer process and the socketHandler process inside of the VideoStream.py file. Because of this the program can only be ran once or twice without restarting before causing issues and I'm currently looking into a fix for this.